### PR TITLE
Terraform module sources do not use a git url with a commit hash revision

### DIFF
--- a/aws/modules/eks_cluster/main.tf
+++ b/aws/modules/eks_cluster/main.tf
@@ -9,7 +9,7 @@ data "aws_caller_identity" "current" {
 # VPC module
 module "vpc" {
   count                                  = var.flag_use_existing_vpc ? 0 : 1
-  source                                 = "git@github.com:DISHDevEx/iot.git//aws/modules/vpc"
+  source                                 = "git@github.com:DISHDevEx/iot.git//aws/modules/vpc?ref=main"
   vpc_name                               = var.vpc_name
   vpc_cidr_block                         = var.vpc_cidr
   vpc_instance_tenancy                   = var.vpc_instance_tenancy
@@ -31,7 +31,7 @@ module "vpc" {
 
 module "eks_execution_role" {
   count                    = var.flag_use_existing_eks_execution_role ? 0 : 1
-  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam"
+  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam?ref=main"
   aws_region               = data.aws_region.current.name
   iam_role_name            = var.eks_role_name
   assume_role_policy       = <<POLICY
@@ -70,7 +70,7 @@ resource "aws_eks_cluster" "eks_cluster_template" {
 
 module "node_group_role" {
   count                    = var.flag_use_existing_node_group_role ? 0 : 1
-  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam"
+  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam?ref=main"
   aws_region               = data.aws_region.current.name
   iam_role_name            = var.existing_node_group_iam_role_arn
   assume_role_policy       = jsonencode({

--- a/aws/modules/eventbridge/main.tf
+++ b/aws/modules/eventbridge/main.tf
@@ -1,5 +1,5 @@
 module "eventbridge" {
-  source  = "terraform-aws-modules/eventbridge/aws"
+  source  = "terraform-aws-modules/eventbridge/aws?ref=master"
   for_each = { for index, config in var.eventbridge_configurations : index => config }
   version = "v1.17.1"
 

--- a/aws/modules/lambda_function/main.tf
+++ b/aws/modules/lambda_function/main.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "iot_lambda_template" {
 
 module "iam" {
   count                    = var.flag_use_existing_role ? 0 : 1
-  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam"
+  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam?ref=main"
   aws_region               = data.aws_region.current.name
   iam_role_name            = var.lambda_role_name
   assume_role_policy       = <<EOF

--- a/aws/modules/step_function/main.tf
+++ b/aws/modules/step_function/main.tf
@@ -29,7 +29,7 @@ locals {
 
 module "sfn_iam" {
   count                    = var.flag_use_existing_role ? 0 : 1
-  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam"
+  source                   = "git@github.com:DISHDevEx/iot.git//aws/modules/iam?ref=main"
   aws_region               = data.aws_region.current.name
   iam_role_name            = var.sfn_role_name
   assume_role_policy       = <<EOF


### PR DESCRIPTION
Resolving: Terraform module sources do not use a git url with a commit hash revision